### PR TITLE
Fix tag references with Farmer's Delight 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     // We add the full version to localRuntime, not runtimeOnly, so that we do not publish a dependency on it
     // localRuntime "mezz.jei:jei-${mc_version}-neoforge:${jei_version}"
 
-    implementation "curse.maven:farmers-delight-398521:5566383"
+    implementation "curse.maven:farmers-delight-398521:8001010"
     implementation "curse.maven:appleskin-248787:5586600"
 
     implementation("mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,13 +29,9 @@ minecraft_version=1.21.1
 minecraft_version_range=[1.21, 1.22)
 
 # NeoForge Version Information
-neo_version=21.1.209
-neo_version_range=[21.0.143,)
+neo_version=21.1.219
+neo_version_range=[21.1.219,)
 loader_version_range=[2,)
-
-# Mappings Information
-forge_mappings_version=1.20.1
-parachment_mappings_version=2023.06.26-1.20.1
 
 # Dependency Information
 jei_mcversion=1.21.1-neoforge

--- a/src/main/java/com/tiviacz/pizzadelight/blockentity/PizzaBlockEntity.java
+++ b/src/main/java/com/tiviacz/pizzadelight/blockentity/PizzaBlockEntity.java
@@ -344,7 +344,7 @@ public class PizzaBlockEntity extends BaseBlockEntity implements MenuProvider, N
         boolean save = false;
 
         if(blockEntity.isRaw()) {
-            if(blockEntity.bakingTime == 0 && level.getBlockState(pos.below()).is(vectorwing.farmersdelight.common.tag.ModTags.HEAT_SOURCES)) {
+            if(blockEntity.bakingTime == 0 && level.getBlockState(pos.below()).is(vectorwing.farmersdelight.common.tag.ModTags.Blocks.HEAT_SOURCES)) {
                 blockEntity.bakingTime = 1;
                 save = true;
             }
@@ -361,7 +361,7 @@ public class PizzaBlockEntity extends BaseBlockEntity implements MenuProvider, N
                 }
             }
 
-            if(!level.getBlockState(pos.below()).is(vectorwing.farmersdelight.common.tag.ModTags.HEAT_SOURCES)) {
+            if(!level.getBlockState(pos.below()).is(vectorwing.farmersdelight.common.tag.ModTags.Blocks.HEAT_SOURCES)) {
                 blockEntity.bakingTime = 0;
             }
         }

--- a/src/main/java/com/tiviacz/pizzadelight/blocks/CheeseBlock.java
+++ b/src/main/java/com/tiviacz/pizzadelight/blocks/CheeseBlock.java
@@ -51,7 +51,7 @@ public class CheeseBlock extends Block {
 
     @Override
     public ItemInteractionResult useItemOn(ItemStack heldStack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-        return heldStack.is(ModTags.KNIVES) ? this.cutCheese(level, pos, state, player.getDirection().getOpposite()) : ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        return heldStack.is(ModTags.Items.KNIVES) ? this.cutCheese(level, pos, state, player.getDirection().getOpposite()) : ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
     }
 
     @Override

--- a/src/main/java/com/tiviacz/pizzadelight/blocks/PizzaBlock.java
+++ b/src/main/java/com/tiviacz/pizzadelight/blocks/PizzaBlock.java
@@ -68,7 +68,7 @@ public class PizzaBlock extends AbstractPizzaBlock {
 
     @Override
     public ItemInteractionResult useItemOn(ItemStack heldStack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-        return heldStack.is(ModTags.KNIVES) ? this.cutSlice(level, pos, state, player.getDirection().getOpposite()) : (heldStack.getItem() instanceof PizzaPeelItem && state.getValue(SLICES) == 0) ? this.pickUpPizza(level, pos, state, player.getDirection().getOpposite()) : ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        return heldStack.is(ModTags.Items.KNIVES) ? this.cutSlice(level, pos, state, player.getDirection().getOpposite()) : (heldStack.getItem() instanceof PizzaPeelItem && state.getValue(SLICES) == 0) ? this.pickUpPizza(level, pos, state, player.getDirection().getOpposite()) : ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
     }
 
     @Override


### PR DESCRIPTION
Closes #12

Fixes an incorrect tag reference that causes crashes with Farmer's Delight 1.3

Also updates NeoForge and Farmer's Delight to more recent versions